### PR TITLE
solved 점프 점프 - 52ms 42660kb

### DIFF
--- a/Baekjoon/점프 점프/점프 점프_이정명.py
+++ b/Baekjoon/점프 점프/점프 점프_이정명.py
@@ -1,0 +1,26 @@
+import sys
+input = sys.stdin.readline
+
+n = int(input())
+A = list(map(int, input().split()))
+s = int(input())
+
+lenA = len(A)
+V = [True for _ in range(lenA)]
+V[s-1] = False
+C = [s-1]
+
+while C:
+    minusC = C[0] - A[C[0]]
+    plusC = C[0] + A[C[0]]
+
+    if minusC >= 0 and V[minusC]:
+        C.append(minusC)
+        V[minusC] = False
+
+    if plusC < lenA and V[plusC]:
+        C.append(plusC)
+        V[plusC] = False
+    C.pop(0)
+
+print(V.count(False))


### PR DESCRIPTION
## 💿 풀이 문제
#37

## 📝 풀이 후기
1차원 탐색 문제였습니다. 52ms 인 사람들 중에서 메모리가 42036kb 인 사람과 42660kb인 사람이 있었는데, 출발지로 설정되어있는 `s`의 재활용 여부에 따른 차이로 보였습니다.
저는 `s`를 사용 후, 원본을 보존했지만, 짧은 사람들은 s를 count 역할로 대체하면서 메모리를 줄인 것으로 보입니다. 좋은지 나쁜지는 모르겠지만, 함수 내부적으로만 사용하는 변수이고, 원본 보존이 필요없었기 때문에, 메모리가 급했다면 나쁘지 않은 선택인 것 같습니다.

## 📚 문제 풀이 핵심 키워드
- (1차원) BFS 탐색

## 🤔 리뷰로 궁금한 점

## 🧑‍💻 제출자 확인 사항
- [x] Convention(commit, pr 제목)이 올바른가요?
- [x] 괄호 내 안내문은 삭제하셨나요?
- [x] 본인의 체감 난도 Label을 등록했나요?
- [x] 제출자 확인 사항을 모두 확인하셨나요?

## 🕵️ 리뷰어 확인 사항
1. 컨벤션이 올바르지 않다면, Request Changes 해주세요.
2. 제출자의 풀이코드의 좋은 점 혹은 개선사항을 남겨주세요.